### PR TITLE
Wrapper for strelka image to facilitate running in CWL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mgibio/strelka:1.0.15
+MAINTAINER Thomas B. Mooney <tmooney@genome.wustl.edu>
+
+LABEL \
+  version="1.0.15" \
+  description="Strelka image adapter for CWL"
+
+ENTRYPOINT [] #clear the inherited entrypoint
+
+ADD cwl_helper.sh /usr/bin/
+CMD ["/usr/bin/cwl_helper.sh"]

--- a/cwl_helper.sh
+++ b/cwl_helper.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+if [ $# -ne 5 ]
+then
+    echo "Usage: $0 [TUMOR_BAM] [NORMAL_BAM] [REFERENCE] [CONFIG] [NUM_CPUS]"
+fi
+
+TUMOR_BAM="$1"
+NORMAL_BAM="$2"
+REFERENCE="$3"
+CONFIG="$4"
+NUM_CPUS="$5"
+
+/usr/bin/docker_helper.sh \
+    "$TUMOR_BAM" \
+    "$NORMAL_BAM" \
+    "$REFERENCE" \
+    "${HOME}/output" \
+    "$CONFIG" \
+    "$NUM_CPUS"


### PR DESCRIPTION
This depends on genome/docker-strelka#1.  It closes genome/arvados_trial#9.
